### PR TITLE
fix: Discard data if CRC is invalid

### DIFF
--- a/C++/MODBUS_WIN_CPP/wit_c_sdk.c
+++ b/C++/MODBUS_WIN_CPP/wit_c_sdk.c
@@ -184,7 +184,8 @@ void WitSerialDataIn(uint8_t ucData)
                 if(usTemp != usCRC16)
                 {
                     s_uiWitDataCnt--;
-                    memcpy(s_ucWitDataBuff, &s_ucWitDataBuff[1], s_uiWitDataCnt);
+                    memset(s_ucWitDataBuff, 0, s_uiWitDataCnt);
+                    s_uiWitDataCnt = 0;
                     return ;
                 }
                 usTemp = s_ucWitDataBuff[2] >> 1;


### PR DESCRIPTION
If the data received is invalid because the CRC does not match, then there is no point continuing. You can safely discard the data. Not to mention that the way `memcpy` is used here is undefined behaviour.

>        Failure to observe the requirement that the memory areas do not
>        overlap has been the source of significant bugs.  (POSIX and the
>        C standards are explicit that employing memcpy() with overlapping
>        areas produces undefined behavior.)
Quote from [man7](https://www.man7.org/linux/man-pages/man3/memcpy.3.html).

I found this problem because a system I am working on may have communication errors with your module. When these errors happen, the callback function passed to `WitRegisterCallBack` is not called. This is the expected behaviour.

But when I make a new data request, the callback never gets called again no matter how many requests I make, and no matter how long I leave my system running, even after confirming there is not communication error.

